### PR TITLE
fix: SVG icons in Icon Box block were not scaling correctly...

### DIFF
--- a/blocks/class-blockstrap-widget-icon-box.php
+++ b/blocks/class-blockstrap-widget-icon-box.php
@@ -877,6 +877,8 @@ class BlockStrap_Widget_Icon_Box extends WP_Super_Duper {
 				// maybe add styles
 				$img_attr['style'] = !empty($args['icon_color']) ? 'fill: currentColor;' . esc_attr( $args['icon_color_custom']).';' : '';
 				$img_attr['style'] .= 'max-width:100%;';
+				$img_attr['style'] .= 'width:1em;';
+				$img_attr['style'] .= 'height:1em;';
 				$img_attr['style'] .= !empty($args['svg_max_height']) ? 'max-height: ' . esc_attr( $args['svg_max_height']).';' : 'max-height: fit-content;';
 				$custom_attr_string = implode(',', array_map(
 					function($key, $value) {


### PR DESCRIPTION
Implemented `width: 1em; height: 1em` on SVG elements to resolve this, ensuring they now scale proportionally with the parent's font size (the font size setting applied to the icon within the editor).